### PR TITLE
create deploy_to before trying to copy files to it

### DIFF
--- a/lib/capper/ruby.rb
+++ b/lib/capper/ruby.rb
@@ -7,6 +7,7 @@ before "deploy:setup", "gemrc:setup"
 namespace :gemrc do
   desc "Setup global ~/.gemrc file"
   task :setup do
+    run "mkdir -p #{deploy_to}"
     put("gem: --no-ri --no-rdoc", "#{deploy_to}/.gemrc")
   end
 end


### PR DESCRIPTION
this fixes the following issue:

when you want to deploy a new app with `deploy:setup` and the `deploy_to` directory does not exist, it throws an error because the `deploy_to` directory does not exist. this happens because `gemrc` task runs before `deploy:setup`. this fix creates the directory. another solution would be, to run `gemrc` task not before but after `deploy:setup`.
